### PR TITLE
Optional onOpened and onClosed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ class Example extends Component {
 - `expandedHeight` view height when expanded (defaults to window height)
 - `closeOnTap` if true, closes on tap
 - `closing` function called when hiding
+- `onClosed` function called after closing animations completed 
+- `onOpened` function called after opening animations completed 
 
 ## Contribute
 

--- a/lib/slideView.js
+++ b/lib/slideView.js
@@ -45,7 +45,11 @@ class SlideView extends Component {
         friction: this.props.friction,
         duration: this.props.showDuration || this.props.duration
       })
-    ]).start();
+    ]).start(() => {
+      if (this.props.onOpened) {
+        this.props.onOpened()
+      }
+    });
   }
 
   hide() {
@@ -64,7 +68,11 @@ class SlideView extends Component {
         friction: this.props.friction,
         duration: this.props.hideDuration || this.props.duration
       })
-    ]).start();
+    ]).start(() => {
+      if (this.props.onClosed) {
+        this.props.onClosed()
+      }
+    });
   }
 
   componentWillReceiveProps(newProps) {
@@ -134,7 +142,9 @@ SlideView.propTypes = {
   hideDuration  : React.PropTypes.number,
   expandedHeight: React.PropTypes.number,
   closeOnTap    : React.PropTypes.bool,
-  closing       : React.PropTypes.func
+  closing       : React.PropTypes.func,
+  onClosed: React.PropTypes.func,
+  onOpened: React.PropTypes.func
 };
 
 SlideView.defaultProps = {


### PR DESCRIPTION
For issue #2 
They get called in the Animated.start() callback if supplied.

See: https://github.com/facebook/react-native/issues/3212